### PR TITLE
Work to address most issues suggested in PR discussion with `ocramz`

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,15 @@
+  1.0.0.0
+	* Changed `process` function API to take a record of callbacks
+	  (breaking change)
+	* Generalized `validate` function type to take any `VectorizedString` instead
+	  of just `ByteString`
+	New features:
+	* Added `VectorizedString` class, and using ByteStringNullTerminated
+	  to make parsing 40-160% faster in common use case.
+	* Added Xeno.DOM.Robust interface for parsing HTML, SGML documents
+	  that may miss closing tags
+	* Added Xeno.SAX.CPS interface for chaining event-based parsers
+
 	0.3.5.2
 	* Fix dependency lower bounds (GHC 8.0.1 is the earliest version currently supported)
 
@@ -10,14 +22,14 @@
 
 	0.3.2
 	Fixed DOM parsing from bystrings with non-zero offset (#11, qrilka)
-	
+
 	0.3
 	Fixed name parsing (for attributes and tags) so it conforms with the XML spec (qrilka)
 	Fixed parsing failure when root tag is preceded by white space (though without checking for white space characters specifically) (qrilka)
-	Added contribution guidelines (ocramz)	
+	Added contribution guidelines (ocramz)
 
 	0.2
-	Added CDATA support (Rembane)	
+	Added CDATA support (Rembane)
 
 	0.1
 	First Hackage release

--- a/bench/Speed.hs
+++ b/bench/Speed.hs
@@ -30,8 +30,7 @@ import qualified Text.XML.LibXML.Parser as Libxml2
 readFileZ :: FilePath -> IO (ByteString, Xeno.Types.ByteStringZeroTerminated)
 readFileZ fn = do
     !s <- S.readFile fn
-    let !sz = Xeno.Types.BSZT (s `S.snoc` 0)
-    return (s,  sz)
+    return (s, Xeno.Types.fromBS s)
 
 
 main :: IO ()

--- a/bench/SpeedBigFiles.hs
+++ b/bench/SpeedBigFiles.hs
@@ -104,8 +104,7 @@ readBZip2File :: FilePath -> IO (ByteString, Xeno.Types.ByteStringZeroTerminated
 readBZip2File fn = do
     file <- L.readFile ("data" </> "ex" </> fn)
     let !bs  = L.toStrict $ decompress file
-        !bsz = Xeno.Types.BSZT $ bs `S.snoc` 0
-    return (bs, bsz)
+    return (bs, Xeno.Types.fromBS bs)
 
 
 deriving instance Generic Content

--- a/benchmark.md
+++ b/benchmark.md
@@ -1,11 +1,13 @@
 # Introduction
 
-There are two issues with old `xeno` benchmarks:
+There are three issues with old `xeno` benchmarks:
 
 * They run on threaded Haskell RTS (compiled with `-threaded`). Threading lead to very big variance in benchmarks
   (sometimes R² is less then 0.8). Therefore threaded benchmarking is not accurate.
 * They run on relatively small files. Some speed improvements become apparent only on big files (more then 100 Mb) and
   benchmarking with small files does not detect an effect of all improvements.
+* Putting `VectorizedString` class into `Xeno.Types` module slows down in 8.6.4, but  not in 8.4.4
+  Benchmarks in 8.6.4 seem also prone to arbitrary changes when the code is reordered.
 
 So here are several type of benchmarks.
 
@@ -13,7 +15,7 @@ So here are several type of benchmarks.
 
 SAX (`xeno-sax` benchmarks):
 
-| size  |xeno threaded | improved xeno threaded | xeno non-threaded | improved xeno non-threaded | imp. xeno w/o copy |
+| size  |xeno 0.3.5.2 threaded | xeno 1.0.0.0 threaded | xeno 0.3.5.2 non-threaded | xeno 1.0.0.0 non-threaded | xeno 1.0.0.0 w/o copy |
 | ----- | ------------ | ---------------------- | ----------------- | -------------------------- | ------------------ |
 | 4KB   | 24.44 μs     | 16.39 μs               | 5.638 μs          | 2.866 μs                   | 2.923 μs           |
 | 31KB  | 13.01 μs     | 121.1 μs               | 2.477 μs          | 1.947 μs                   | 1.289 μs           |
@@ -26,7 +28,7 @@ SAX (`xeno-sax` benchmarks):
 
 DOM (`xeno-dom` and `hexml-dom` benchmarks):
 
-| size  |xeno threaded | improved xeno threaded | hexml-dom threaded | xeno unthreaded | improved xeno non-threaded | imp. xeno w/o copy | hexml-dom non-threaded |
+| size  |xeno 0.3.5.2 threaded | xeno 1.0.0.0 threaded | hexml-dom threaded xeno 0.3.5.2 unthreaded | xeno 1.0.0.0 unthreaded | xeno 1.0.0.0 w/o copy | hexml-dom non-threaded |
 | ----- | ------------ | ---------------------- | ------------------ | --------------- | -------------------------- | ------------------ | ---------------------- |
 | 4KB   | 29.46 μs     | 40.96 μs               | 10.84 μs           | 9.023 μs        | 6.174 μs                   | 6.251 μs           | 3.290 μs               |
 | 31KB  | 29.04 μs     | 167.7 μs               | 82.60 μs           | 4.020 μs        | 3.433 μs                   | 2.921 μs           | 2.813 μs               |
@@ -66,21 +68,20 @@ Please note **huge** variance introduced by outliers and low R².
 
 Memory:
 
-```
-Case                          Allocated  GCs
-4kb_hexml_dom                     3,808    0
-4kb_xeno_sax                      3,856    0
-4kb_xeno_dom                     12,416    0
-4kb_xeno_dom-with-recovery       18,360    0
-31kb_hexml_dom                   30,608    0
-31kb_xeno_sax                    30,440    0
-31kb_xeno_dom                    62,320    0
-31kb_xeno_dom-with-recovery      41,488    0
-211kb_hexml_dom                 211,752    0
-211kb_xeno_sax                  247,640    0
-211kb_xeno_dom                  930,160    0
-211kb_xeno_dom-with-recovery  1,549,408    0
-```
+Case                         | Allocated | GCs
+---------------------------- | --------- | ---
+4kb_hexml_dom                |     3,808 |  0
+4kb_xeno_sax                 |     3,856 |  0
+4kb_xeno_dom                 |    12,416 |  0
+4kb_xeno_dom-with-recovery   |    18,360 |  0
+31kb_hexml_dom               |    30,608 |  0
+31kb_xeno_sax                |    30,440 |  0
+31kb_xeno_dom                |    62,320 |  0
+31kb_xeno_dom-with-recovery  |    41,488 |  0
+211kb_hexml_dom              |   211,752 |  0
+211kb_xeno_sax               |   247,640 |  0
+211kb_xeno_dom               |   930,160 |  0
+211kb_xeno_dom-with-recovery | 1,549,408 |  0
 
 Speed:
 
@@ -232,7 +233,7 @@ std dev              16.85 ms   (6.239 ms .. 21.98 ms)
 variance introduced by outliers: 19% (moderately inflated)
 ```
 
-### Before speed improvements
+### Before speed improvements (v0.3.5.2)
 
 Memory:
 
@@ -408,7 +409,7 @@ Compiled with `ghc-options: -O2 -rtsopts`.
 
 Please note almost lack of variance introduced by outliers and high R².
 
-### Current benchmarks
+### Current benchmarks (v1.0.0.0)
 
 Memory:
 
@@ -567,7 +568,7 @@ variance introduced by outliers: 16% (moderately inflated)
 Benchmark xeno-speed-bench: FINISH
 ```
 
-### Before speed improvements
+### Before speed improvements (v0.3.5.2)
 
 Memory:
 
@@ -732,7 +733,7 @@ Benchmarks ran with `--time-limit 60` to eliminate variance.
 
 Compiled with `ghc-options: -O2 -rtsopts "-with-rtsopts=-H10G -AL1G -A256m -M25G"`.
 
-### Current benchmarks
+### Current benchmarks (v1.0.0.0)
 
 
 ```
@@ -862,7 +863,7 @@ std dev              241.4 ms   (7.854 ms .. 327.5 ms)
 variance introduced by outliers: 16% (moderately inflated)
 ```
 
-### Before speed improvements
+### Before speed improvements (v0.3.5.2)
 
 ```
 benchmarking 46MB/xeno-sax
@@ -1096,7 +1097,7 @@ std dev              100.4 ms   (53.00 ms .. 154.0 ms)
 variance introduced by outliers: 14% (moderately inflated)
 ```
 
-### Before speed improvements
+### Before speed improvements (v0.3.5.2)
 
 
 ```

--- a/src/Xeno/DOM.hs
+++ b/src/Xeno/DOM.hs
@@ -1,8 +1,4 @@
-{-# LANGUAGE BangPatterns               #-}
-{-# LANGUAGE DeriveAnyClass             #-}
-{-# LANGUAGE DeriveDataTypeable         #-}
-{-# LANGUAGE DeriveGeneric              #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE BangPatterns #-}
 -- | DOM parser and API for XML.
 
 module Xeno.DOM
@@ -17,16 +13,16 @@ module Xeno.DOM
 
 import           Control.Monad.ST
 import           Control.Spork
-import           Data.ByteString          (ByteString)
-import           Data.ByteString.Internal (ByteString(PS))
-import qualified Data.ByteString as S
+import           Data.ByteString             (ByteString)
+import qualified Data.ByteString             as S
+import           Data.ByteString.Internal    (ByteString (PS))
 import           Data.Mutable
 import           Data.STRef
-import qualified Data.Vector.Unboxed as UV
+import qualified Data.Vector.Unboxed         as UV
 import qualified Data.Vector.Unboxed.Mutable as UMV
+import           Xeno.DOM.Internal
 import           Xeno.SAX
 import           Xeno.Types
-import           Xeno.DOM.Internal
 
 -- | Parse a complete Nodes document.
 parse :: ByteString -> Either XenoException Node
@@ -82,7 +78,7 @@ parse str =
                               return v'
                      let tag = 0x02
                      do writeRef sizeRef (index + 5)
-                     do UMV.unsafeWrite v' index tag
+                        UMV.unsafeWrite v' index tag
                         UMV.unsafeWrite v' (index + 1) (key_start - offset0)
                         UMV.unsafeWrite v' (index + 2) key_len
                         UMV.unsafeWrite v' (index + 3) (value_start - offset0)
@@ -100,7 +96,7 @@ parse str =
                               writeSTRef vecRef v'
                               return v'
                      do writeRef sizeRef (index + 3)
-                     do UMV.unsafeWrite v' index tag
+                        UMV.unsafeWrite v' index tag
                         UMV.unsafeWrite v' (index + 1) (text_start - offset0)
                         UMV.unsafeWrite v' (index + 2) text_len
               , closeF = \_ -> do

--- a/src/Xeno/Errors.hs
+++ b/src/Xeno/Errors.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Strict            #-}
-{-# LANGUAGE ViewPatterns      #-}
-{-# LANGUAGE CPP               #-}
 -- | Simplifies raising and presenting localized exceptions to the user.
 module Xeno.Errors(printExceptions
                   ,displayException
@@ -9,10 +7,10 @@ module Xeno.Errors(printExceptions
                   ,failHere
                   ) where
 
-import           Data.Semigroup((<>))
-import qualified Data.ByteString.Char8 as BS hiding (elem)
-import           Data.ByteString.Internal(ByteString(..))
-import           System.IO(stderr)
+import qualified Data.ByteString.Char8    as BS hiding (elem)
+import           Data.ByteString.Internal (ByteString (..))
+import           Data.Semigroup           ((<>))
+import           System.IO                (stderr)
 
 import           Xeno.Types
 
@@ -58,4 +56,3 @@ revTake i (PS ptr from to) = PS ptr (end-len) len
   where
     end = from + to
     len = min to i
-

--- a/src/Xeno/SAX.hs
+++ b/src/Xeno/SAX.hs
@@ -11,7 +11,7 @@
 module Xeno.SAX
   ( process
   , Process(..)
-  , StringLike(..)
+  , VectorizedString(..)
   , fold
   , validate
   , validateEx
@@ -27,55 +27,11 @@ import           Data.Bits
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Char8 as S8
-import qualified Data.ByteString.Unsafe as SU
-import           Data.Char(isSpace)
 import           Data.Functor.Identity
-import           Data.Semigroup
 import           Data.STRef
 import           Data.Word
 import           Xeno.Types
-
-
-class StringLike str where
-    s_index'       :: str -> Int -> Word8
-    elemIndexFrom' :: Word8 -> str -> Int -> Maybe Int
-    drop'          :: Int -> str -> str
-    substring'     :: str -> Int -> Int -> ByteString
-    toBS           :: str -> ByteString
-
-instance StringLike ByteString where
-    s_index'       = s_index
-    {-# INLINE s_index' #-}
-    elemIndexFrom' = elemIndexFrom
-    {-# INLINE elemIndexFrom' #-}
-    drop'          = S.drop
-    {-# INLINE drop' #-}
-    substring'     = substring
-    {-# INLINE substring' #-}
-    toBS           = id
-    {-# INLINE toBS #-}
-
-instance StringLike ByteStringZeroTerminated where
-    s_index' (BSZT ps) n = ps `SU.unsafeIndex` n
-    {-# INLINE s_index' #-}
-    elemIndexFrom' w (BSZT bs) i = elemIndexFrom w bs i
-    {-# INLINE elemIndexFrom' #-}
-    drop' i (BSZT bs) = BSZT $ S.drop i bs
-    {-# INLINE drop' #-}
-    substring' (BSZT bs) s t = substring bs s t
-    {-# INLINE substring' #-}
-    toBS (BSZT bs) = bs
-    {-# INLINE toBS #-}
-
-data Process a =
-  Process {
-      openF    :: !(ByteString ->               a) -- ^ Open tag.
-    , attrF    :: !(ByteString -> ByteString -> a) -- ^ Tag attribute.
-    , endOpenF :: !(ByteString ->               a) -- ^ End open tag.
-    , textF    :: !(ByteString ->               a) -- ^ Text.
-    , closeF   :: !(ByteString ->               a) -- ^ Close tag.
-    , cdataF   :: !(ByteString ->               a) -- ^ CDATA.
-    }
+import           Data.Char(isSpace)
 
 --------------------------------------------------------------------------------
 -- Helpful interfaces to the parser
@@ -90,7 +46,7 @@ data Process a =
 --
 -- > > validate "<b"
 -- > False
-validate :: (StringLike str) => str -> Bool
+validate :: (VectorizedString str) => str -> Bool
 validate s =
   case spork
          (runIdentity
@@ -114,7 +70,7 @@ validate s =
 
 -- | Parse the XML and checks tags nesting.
 --
-validateEx :: (StringLike str) => str -> Bool
+validateEx :: (VectorizedString str) => str -> Bool
 validateEx s =
   case spork
          (runST $ do
@@ -205,18 +161,18 @@ fold openF attrF endOpenF textF closeF cdataF s str =
 
 -- | Process events with callbacks in the XML input.
 process
-  :: (Monad m, StringLike str)
-  => Process (m ())
+  :: (Monad m, VectorizedString str)
+  => Process str (m ())
   -> str
   -> m ()
 process !(Process {openF, attrF, endOpenF, textF, closeF, cdataF}) str = findLT 0
   where
     findLT index =
       case elemIndexFrom' openTagChar str index of
-        Nothing -> unless (S.null text) (textF text)
-          where text = toBS $ drop' index str
+        Nothing -> unless (s_null text) (textF text)
+          where text = drop' index str
         Just fromLt -> do
-          unless (S.null text) (textF text)
+          unless (s_null text) (textF text)
           checkOpenComment (fromLt + 1)
           where text = substring' str index fromLt
     -- Find open comment, CDATA or tag name.
@@ -320,49 +276,36 @@ process !(Process {openF, attrF, endOpenF, textF, closeF, cdataF}) str = findLT 
       where
         index = skipSpaces str index0
 {-# INLINE process #-}
-{-# SPECIALISE process :: Process (Identity ()) -> ByteString -> Identity ()
+{-# SPECIALISE process :: Process ByteString (Identity ()) -> ByteString -> Identity ()
                #-}
-{-# SPECIALISE process :: Process (State s ()) -> ByteString -> State s ()
+{-# SPECIALISE process :: Process ByteString (State s  ()) -> ByteString -> State s  ()
                #-}
-{-# SPECIALISE process :: Process (ST s ()) -> ByteString -> ST s ()
+{-# SPECIALISE process :: Process ByteString (ST    s  ()) -> ByteString -> ST    s  ()
                #-}
-{-# SPECIALISE process :: Process (IO ()) -> ByteString -> IO ()
+{-# SPECIALISE process :: Process ByteString (IO       ()) -> ByteString -> IO       ()
                #-}
-{-# SPECIALISE process :: Process (Identity ()) -> ByteStringZeroTerminated -> Identity ()
+{-# SPECIALISE process :: Process ByteStringZeroTerminated (Identity ()) -> ByteStringZeroTerminated -> Identity ()
                #-}
-{-# SPECIALISE process :: Process (State s ()) -> ByteStringZeroTerminated -> State s ()
+{-# SPECIALISE process :: Process ByteStringZeroTerminated (State  s ()) -> ByteStringZeroTerminated -> State s ()
                #-}
-{-# SPECIALISE process :: Process (ST s ()) -> ByteStringZeroTerminated -> ST s ()
+{-# SPECIALISE process :: Process ByteStringZeroTerminated (ST     s ()) -> ByteStringZeroTerminated -> ST    s ()
                #-}
-{-# SPECIALISE process :: Process (IO ()) -> ByteStringZeroTerminated -> IO ()
+{-# SPECIALISE process :: Process ByteStringZeroTerminated (IO       ()) -> ByteStringZeroTerminated -> IO      ()
                #-}
 
 --------------------------------------------------------------------------------
 -- ByteString utilities
 
--- | /O(1)/ 'ByteString' index (subscript) operator, starting from 0.
-s_index :: ByteString -> Int -> Word8
-s_index ps n
-    | n < 0            = throw (XenoStringIndexProblem n ps)
-    | n >= S.length ps = throw (XenoStringIndexProblem n ps)
-    | otherwise        = ps `SU.unsafeIndex` n
-{-# INLINE s_index #-}
-
 -- | A fast space skipping function.
-skipSpaces :: (StringLike str) => str -> Int -> Int
+skipSpaces :: (VectorizedString str) => str -> Int -> Int
 skipSpaces str i =
   if isSpaceChar (s_index' str i)
     then skipSpaces str (i + 1)
     else i
 {-# INLINE skipSpaces #-}
 
--- | Get a substring of a string.
-substring :: ByteString -> Int -> Int -> ByteString
-substring s start end = S.take (end - start) (S.drop start s)
-{-# INLINE substring #-}
-
 -- | Basically @findIndex (not . isNameChar)@, but doesn't allocate.
-parseName :: (StringLike str) => str -> Int -> Int
+parseName :: (VectorizedString str) => str -> Int -> Int
 parseName str index =
   if not (isNameChar1 (s_index' str index))
      then index
@@ -370,20 +313,12 @@ parseName str index =
 {-# INLINE parseName #-}
 
 -- | Basically @findIndex (not . isNameChar)@, but doesn't allocate.
-parseName' :: (StringLike str) => str -> Int -> Int
+parseName' :: (VectorizedString str) => str -> Int -> Int
 parseName' str index =
   if not (isNameChar (s_index' str index))
      then index
      else parseName' str (index + 1)
 {-# INLINE parseName' #-}
-
--- | Get index of an element starting from offset.
-elemIndexFrom :: Word8 -> ByteString -> Int -> Maybe Int
-elemIndexFrom c str offset = fmap (+ offset) (S.elemIndex c (S.drop offset str))
--- Without the INLINE below, the whole function is twice as slow and
--- has linear allocation. See git commit with this comment for
--- results.
-{-# INLINE elemIndexFrom #-}
 
 --------------------------------------------------------------------------------
 -- Character types

--- a/src/Xeno/SAX.hs
+++ b/src/Xeno/SAX.hs
@@ -339,21 +339,6 @@ isNameChar1 c =
   (c >= 97 && c <= 122) || (c >= 65 && c <= 90) || c == 95 || c == 58
 {-# INLINE isNameChar1 #-}
 
--- isNameCharOriginal :: Word8 -> Bool
--- isNameCharOriginal c =
---   (c >= 97 && c <= 122) || (c >= 65 && c <= 90) || c == 95 || c == 58 ||
---   c == 45 || c == 46 || (c >= 48 && c <= 57)
--- {-# INLINE isNameCharOriginal #-}
---
--- TODO Strange, but highMaskIsNameChar, lowMaskIsNameChar don't calculate fast... FIX IT
--- highMaskIsNameChar, lowMaskIsNameChar :: Word64
--- (highMaskIsNameChar, lowMaskIsNameChar) =
---     foldl (\(hi,low) char -> (hi `setBit` (char - 64), low `setBit` char)) -- NB: `setBit` can process overflowed values (where char < 64; -- TODO fix it
---           (0::Word64, 0::Word64)
---           (map fromIntegral (filter isNameCharOriginal [0..128]))
--- {-# INLINE highMaskIsNameChar #-}
--- {-# INLINE lowMaskIsNameChar #-}
-
 -- | Is the character a valid tag/attribute name constituent?
 -- isNameChar1 + '-', '.', '0'-'9'
 isNameChar :: Word8 -> Bool

--- a/src/Xeno/SAX/CPS.hs
+++ b/src/Xeno/SAX/CPS.hs
@@ -1,10 +1,7 @@
+{-# LANGUAGE GADTs               #-}
 {-# LANGUAGE MultiWayIf          #-}
-{-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE BangPatterns        #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TypeFamilies        #-}
 
 -- | SAX parser and API for XML.
 
@@ -13,14 +10,14 @@ module Xeno.SAX.CPS
   ) where
 
 import           Control.Exception
-import           Control.Monad.State.Strict
 import           Control.Monad.ST.Strict
+import           Control.Monad.State.Strict
 import           Control.Spork
-import           Data.ByteString (ByteString)
-import qualified Data.ByteString as S
-import qualified Data.ByteString.Char8 as S8
-import qualified Data.ByteString.Unsafe as SU
-import           Data.Char(isSpace)
+import           Data.ByteString             (ByteString)
+import qualified Data.ByteString             as S
+import qualified Data.ByteString.Char8       as S8
+import qualified Data.ByteString.Unsafe      as SU
+import           Data.Char                   (isSpace)
 import           Data.Functor.Identity
 import           Data.Monoid
 import           Data.Word
@@ -31,7 +28,7 @@ import           Data.STRef
 import qualified Data.Vector.Unboxed as UV -}
 import qualified Data.Vector.Unboxed.Mutable as UMV
 
-import Xeno.SAX
+import           Xeno.SAX
 
 cps ::       Process (ST s b)            -- initial processor
     -> ST s (Process (ST s b),           -- mutable processor
@@ -64,6 +61,6 @@ pushdown p = do
   (proc, next) <- cps p
   stackSize  <- newSTRef 0
   stackAlloc <- newSTRef 16
-  stack      <- 
+  stack      <-
   let call aProc = do
 -}

--- a/src/Xeno/Types.hs
+++ b/src/Xeno/Types.hs
@@ -8,18 +8,23 @@
 
 module Xeno.Types where
 
-import Control.DeepSeq
-import Control.Exception
-import Data.ByteString.Char8 (ByteString, pack)
-import Data.Data
-import GHC.Generics
+import           Control.DeepSeq
+import           Control.Exception
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString as S
+import qualified Data.ByteString.Char8 as S8
+import qualified Data.ByteString.Unsafe as SU
+import           Data.Data
+import           Data.String     (IsString(..))
+import           Data.Word
+import           GHC.Generics
 
 #if MIN_VERSION_base(4,9,0)
 import Control.Monad.Fail
 
 -- It is recommended to use more specific `failHere` instead
 instance MonadFail (Either Xeno.Types.XenoException) where
-  fail = Left . XenoParseError 0 . pack
+  fail = Left . XenoParseError 0 . S8.pack
 #endif
 
 data XenoException
@@ -30,6 +35,98 @@ data XenoException
 
 instance Exception XenoException where displayException = show
 
--- | ByteString wich guaranted have '\NUL' at the end
-newtype ByteStringZeroTerminated = BSZT ByteString deriving (Generic, NFData)
+-- | ByteString guaranted have '\NUL' at the end
+newtype ByteStringZeroTerminated =
+  BSZT ByteString deriving (Eq, Show, Typeable, Generic, NFData)
 
+instance IsString ByteStringZeroTerminated where
+  fromString = fromBS
+             . fromString
+
+fromBS  :: S.ByteString -> ByteStringZeroTerminated
+fromBS s = BSZT $ S.init $ s `S.snoc` 0
+
+-- | VectorizedString class defines
+--   minimal efficient interface for
+--   **character arrays**.
+--   It is a set of operations sufficient
+--   for extremely fast parsing.
+--
+--   Operations are so chosen as to
+--   facilitate vectorization by LLVM,
+--   and extraction of ByteString result.
+class ( Show           str
+      , Eq             str
+      , IsString       str
+      )
+   => VectorizedString str where
+    s_index'       ::          str -> Int -> Word8
+    elemIndexFrom' :: Word8 -> str -> Int -> Maybe Int
+    drop'          :: Int   -> str ->                     str
+    substring'     ::          str -> Int ->       Int -> str
+    s_null         ::          str -> Bool
+    --vs_fromBS      :: ByteString   ->                     str
+    --toBS           ::          str -> ByteString
+
+instance VectorizedString ByteString where
+    s_null         = S.null
+    {-# INLINE s_null #-}
+    s_index'       = s_index
+    {-# INLINE s_index' #-}
+    elemIndexFrom' = elemIndexFrom
+    {-# INLINE elemIndexFrom' #-}
+    drop'          = S.drop
+    {-# INLINE drop' #-}
+    substring'     = substring
+    {-# INLINE substring' #-}
+
+-- | Same as ByteString, but with additional
+--   invariant that requires it to be null terminated.
+instance VectorizedString ByteStringZeroTerminated where
+    s_null           (BSZT ps)     = S.null ps
+    {-# INLINE s_null #-}
+    s_index'         (BSZT ps) n   = ps `SU.unsafeIndex` n
+    {-# INLINE s_index' #-}
+    elemIndexFrom' w (BSZT bs) i   = elemIndexFrom w bs i
+    {-# INLINE elemIndexFrom' #-}
+    drop'          i (BSZT bs)     = BSZT $ S.drop i bs
+    {-# INLINE drop' #-}
+    substring'       (BSZT bs) s t = BSZT $ substring bs s t
+    {-# INLINE substring' #-}
+
+-- | A set of callbacks used for SAX parsing.
+--   High level interface that allows one
+--   to easily implement extension,
+--   inheritance, and composition on event parser
+--   without sacrificing performance.
+data VectorizedString s
+  => Process s a =
+  Process {
+      openF    :: !(s ->      a) -- ^ Open tag.
+    , attrF    :: !(s -> s -> a) -- ^ Tag attribute.
+    , endOpenF :: !(s ->      a) -- ^ End open tag.
+    , textF    :: !(s ->      a) -- ^ Text.
+    , closeF   :: !(s ->      a) -- ^ Close tag.
+    , cdataF   :: !(s ->      a) -- ^ CDATA.
+    }
+
+-- | /O(1)/ 'ByteString' index (subscript) operator, starting from 0.
+s_index :: ByteString -> Int -> Word8
+s_index ps n
+    | n < 0            = throw (XenoStringIndexProblem n ps)
+    | n >= S.length ps = throw (XenoStringIndexProblem n ps)
+    | otherwise        = ps `SU.unsafeIndex` n
+{-# INLINE s_index #-}
+
+-- | Get a substring of a string.
+substring :: ByteString -> Int -> Int -> ByteString
+substring s start end = S.take (end - start) (S.drop start s)
+{-# INLINE substring #-}
+
+-- | Get index of an element starting from offset.
+elemIndexFrom :: Word8 -> ByteString -> Int -> Maybe Int
+elemIndexFrom c str offset = fmap (+ offset) (S.elemIndex c (S.drop offset str))
+-- Without the INLINE below, the whole function is twice as slow and
+-- has linear allocation. See git commit with this comment for
+-- results.
+{-# INLINE elemIndexFrom #-}

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # resolver: lts-7.24
 # resolver: lts-11.8
-# resolver: lts-12.26
-resolver: lts-13.30
+resolver: lts-12.26
+#resolver: lts-13.30
 packages:
 - .
 extra-deps:

--- a/xeno.cabal
+++ b/xeno.cabal
@@ -1,5 +1,5 @@
 name: xeno
-version: 0.3.5.2
+version: 1.0.0.0
 synopsis: A fast event-based XML parser in pure Haskell
 description: A fast, low-memory use, event-based XML parser in pure Haskell.  
 build-type: Simple


### PR DESCRIPTION
The benchmarks with Stack `resolver: lts-12.26`, since we reorder some code:

# New version
```
xeno-0.3.5.2: unregistering
xeno> configure (lib + exe + bench)
Configuring xeno-1.0.0.0...
xeno> build (lib + exe + bench)
Preprocessing library for xeno-1.0.0.0..
Building library for xeno-1.0.0.0..
[1 of 7] Compiling Control.Spork
[2 of 7] Compiling Xeno.DOM.Internal
[3 of 7] Compiling Xeno.Types
[4 of 7] Compiling Xeno.SAX
[5 of 7] Compiling Xeno.Errors
[6 of 7] Compiling Xeno.DOM.Robust
[7 of 7] Compiling Xeno.DOM
Preprocessing benchmark 'xeno-speed-bench' for xeno-1.0.0.0..
Building benchmark 'xeno-speed-bench' for xeno-1.0.0.0..
[1 of 1] Compiling Main
Linking .stack-work/dist/x86_64-linux-tinfo6/Cabal-2.2.0.1/build/xeno-speed-bench/xeno-speed-bench ...
Preprocessing benchmark 'xeno-speed-big-files-bench' for xeno-1.0.0.0..
Building benchmark 'xeno-speed-big-files-bench' for xeno-1.0.0.0..
[1 of 1] Compiling Main
Linking .stack-work/dist/x86_64-linux-tinfo6/Cabal-2.2.0.1/build/xeno-speed-big-files-bench/xeno-speed-big-files-bench ...
Preprocessing executable 'xeno-bench' for xeno-1.0.0.0..
Building executable 'xeno-bench' for xeno-1.0.0.0..
[1 of 1] Compiling Main [Xeno.DOM changed]
Linking .stack-work/dist/x86_64-linux-tinfo6/Cabal-2.2.0.1/build/xeno-bench/xeno-bench ...
Preprocessing benchmark 'xeno-memory-bench' for xeno-1.0.0.0..
Building benchmark 'xeno-memory-bench' for xeno-1.0.0.0..
[1 of 1] Compiling Main [Xeno.SAX changed]
Linking .stack-work/dist/x86_64-linux-tinfo6/Cabal-2.2.0.1/build/xeno-memory-bench/xeno-memory-bench ...
xeno> copy/register
Installing library in /home/m/src/xeno-dmalkr/.stack-work/install/x86_64-linux-tinfo6/25e5392c28977379b061edcf1be6bb82d2a131f3dad611ea5eb4ec9e792c41da/8.4.4/lib/x86_64-linux-ghc-8.4.4/xeno-1.0.0.0-Hgu8QymeYdI3vSjKyCO4Ge
Installing executable xeno-bench in /home/m/src/xeno-dmalkr/.stack-work/install/x86_64-linux-tinfo6/25e5392c28977379b061edcf1be6bb82d2a131f3dad611ea5eb4ec9e792c41da/8.4.4/bin
Registering library for xeno-1.0.0.0..
xeno> benchmarks
Progress 1/2: xeno

Running 3 benchmarks...
Benchmark xeno-memory-bench: RUNNING...

Case                          Allocated  GCs
4kb_hexml_dom                     3,496    0
4kb_xeno_sax                      6,016    0
4kb_xeno_dom                     21,512    0
4kb_xeno_dom-with-recovery       28,096    0
31kb_hexml_dom                   30,296    0
31kb_xeno_sax                     2,296    0
31kb_xeno_dom                    36,224    0
31kb_xeno_dom-with-recovery      16,360    0
211kb_hexml_dom                 211,496    0
211kb_xeno_sax                  352,768    0
211kb_xeno_dom                1,379,952    0
211kb_xeno_dom-with-recovery  1,999,240    0
Benchmark xeno-memory-bench: FINISH
Benchmark xeno-speed-bench: RUNNING...
benchmarking 4KB/hexml-dom
time                 6.051 μs   (6.009 μs .. 6.101 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 6.042 μs   (6.020 μs .. 6.069 μs)
std dev              78.44 ns   (56.73 ns .. 104.4 ns)

benchmarking 4KB/xeno-sax
time                 4.411 μs   (4.393 μs .. 4.433 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 4.417 μs   (4.402 μs .. 4.431 μs)
std dev              49.02 ns   (41.20 ns .. 57.32 ns)

benchmarking 4KB/xeno-sax-z
time                 3.166 μs   (3.154 μs .. 3.177 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 3.168 μs   (3.160 μs .. 3.177 μs)
std dev              29.12 ns   (25.59 ns .. 34.11 ns)

benchmarking 4KB/xeno-sax-ex
time                 6.155 μs   (6.139 μs .. 6.171 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 6.142 μs   (6.134 μs .. 6.153 μs)
std dev              32.46 ns   (26.11 ns .. 41.24 ns)

benchmarking 4KB/xeno-sax-ex-z
time                 5.136 μs   (5.124 μs .. 5.148 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 5.131 μs   (5.122 μs .. 5.142 μs)
std dev              33.33 ns   (26.84 ns .. 41.29 ns)

benchmarking 4KB/xeno-dom
time                 7.954 μs   (7.920 μs .. 8.003 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 7.941 μs   (7.922 μs .. 7.970 μs)
std dev              76.81 ns   (55.82 ns .. 120.1 ns)

benchmarking 4KB/xeno-dom-with-recovery
time                 10.21 μs   (10.17 μs .. 10.25 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 10.22 μs   (10.20 μs .. 10.26 μs)
std dev              92.60 ns   (77.59 ns .. 114.2 ns)

benchmarking 4KB/hexpat-sax
time                 41.66 μs   (41.54 μs .. 41.80 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 41.67 μs   (41.60 μs .. 41.76 μs)
std dev              274.3 ns   (220.0 ns .. 337.0 ns)

benchmarking 4KB/hexpat-dom
time                 109.0 μs   (108.4 μs .. 109.7 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 108.8 μs   (108.5 μs .. 109.2 μs)
std dev              1.130 μs   (913.0 ns .. 1.416 μs)

benchmarking 4KB/xml-dom
time                 819.9 μs   (817.3 μs .. 822.7 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 830.5 μs   (827.5 μs .. 835.4 μs)
std dev              12.48 μs   (9.709 μs .. 19.17 μs)

benchmarking 31KB/hexml-dom
time                 5.307 μs   (5.292 μs .. 5.325 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 5.306 μs   (5.293 μs .. 5.319 μs)
std dev              43.10 ns   (35.62 ns .. 53.17 ns)

benchmarking 31KB/xeno-sax
time                 1.924 μs   (1.920 μs .. 1.930 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.925 μs   (1.921 μs .. 1.937 μs)
std dev              21.65 ns   (11.38 ns .. 40.20 ns)

benchmarking 31KB/xeno-sax-z
time                 1.351 μs   (1.347 μs .. 1.354 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.351 μs   (1.349 μs .. 1.354 μs)
std dev              9.029 ns   (7.594 ns .. 10.91 ns)

benchmarking 31KB/xeno-sax-ex
time                 2.798 μs   (2.793 μs .. 2.803 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 2.795 μs   (2.792 μs .. 2.799 μs)
std dev              12.36 ns   (9.513 ns .. 16.43 ns)

benchmarking 31KB/xeno-sax-ex-z
time                 2.450 μs   (2.444 μs .. 2.458 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 2.448 μs   (2.444 μs .. 2.453 μs)
std dev              14.12 ns   (9.979 ns .. 20.21 ns)

benchmarking 31KB/xeno-dom
time                 3.497 μs   (3.493 μs .. 3.502 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 3.496 μs   (3.491 μs .. 3.502 μs)
std dev              18.86 ns   (15.06 ns .. 26.48 ns)

benchmarking 31KB/xeno-dom-with-recovery
time                 4.496 μs   (4.488 μs .. 4.505 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 4.504 μs   (4.494 μs .. 4.516 μs)
std dev              33.88 ns   (25.94 ns .. 46.09 ns)

benchmarking 31KB/hexpat-sax
time                 86.61 μs   (86.23 μs .. 86.98 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 86.71 μs   (86.46 μs .. 86.98 μs)
std dev              810.5 ns   (711.1 ns .. 929.8 ns)

benchmarking 31KB/hexpat-dom
time                 153.6 μs   (153.3 μs .. 153.9 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 153.9 μs   (153.7 μs .. 154.4 μs)
std dev              1.115 μs   (716.0 ns .. 1.977 μs)

benchmarking 31KB/xml-dom
time                 5.172 ms   (5.148 ms .. 5.199 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 5.169 ms   (5.156 ms .. 5.187 ms)
std dev              44.25 μs   (33.76 μs .. 64.53 μs)

benchmarking 211KB/hexml-dom
time                 163.3 μs   (162.7 μs .. 164.0 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 163.3 μs   (162.9 μs .. 163.6 μs)
std dev              1.235 μs   (1.085 μs .. 1.456 μs)

benchmarking 211KB/xeno-sax
time                 214.8 μs   (214.2 μs .. 215.4 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 214.5 μs   (214.1 μs .. 214.9 μs)
std dev              1.383 μs   (1.157 μs .. 1.659 μs)

benchmarking 211KB/xeno-sax-z
time                 154.4 μs   (153.8 μs .. 155.4 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 154.1 μs   (153.9 μs .. 154.5 μs)
std dev              1.008 μs   (710.9 ns .. 1.622 μs)

benchmarking 211KB/xeno-sax-ex
time                 298.4 μs   (298.1 μs .. 298.8 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 299.7 μs   (299.1 μs .. 300.6 μs)
std dev              2.503 μs   (1.736 μs .. 3.818 μs)

benchmarking 211KB/xeno-sax-ex-z
time                 250.8 μs   (250.3 μs .. 251.3 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 251.3 μs   (250.9 μs .. 252.0 μs)
std dev              1.893 μs   (1.508 μs .. 2.394 μs)

benchmarking 211KB/xeno-dom
time                 388.2 μs   (387.0 μs .. 389.4 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 387.7 μs   (387.0 μs .. 388.6 μs)
std dev              2.711 μs   (2.155 μs .. 3.320 μs)

benchmarking 211KB/xeno-dom-with-recovery
time                 505.4 μs   (503.6 μs .. 507.6 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 511.5 μs   (508.8 μs .. 515.6 μs)
std dev              10.95 μs   (8.132 μs .. 16.44 μs)
variance introduced by outliers: 12% (moderately inflated)

benchmarking 211KB/hexpat-sax
time                 4.466 ms   (4.437 ms .. 4.496 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 4.472 ms   (4.447 ms .. 4.502 ms)
std dev              85.28 μs   (65.80 μs .. 139.5 μs)

benchmarking 211KB/hexpat-dom
time                 9.748 ms   (9.714 ms .. 9.780 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 9.727 ms   (9.690 ms .. 9.765 ms)
std dev              98.06 μs   (76.42 μs .. 132.8 μs)

benchmarking 211KB/xml-dom
time                 47.55 ms   (46.58 ms .. 48.51 ms)
                     0.999 R²   (0.997 R² .. 1.000 R²)
mean                 48.50 ms   (47.92 ms .. 49.28 ms)
std dev              1.288 ms   (918.8 μs .. 1.747 ms)

Benchmark xeno-speed-bench: FINISH
Benchmark xeno-speed-big-files-bench: RUNNING...
xeno-speed-big-files-bench: data/ex/enwiki-20190901-pages-articles14.xml-p7697599p7744799.bz2: openBinaryFile: does not exist (No such file or directory)
Benchmark xeno-speed-big-files-bench: ERROR
Completed 2 action(s).

--  While building package xeno-1.0.0.0 using:
      /home/m/.stack/setup-exe-cache/x86_64-linux-tinfo6/Cabal-simple_mPHDZzAJ_2.2.0.1_ghc-8.4.4 --builddir=.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.2.0.1 bench xeno-memory-bench xeno-speed-bench xeno-speed-big-files-bench
    Process exited with code: ExitFailure 1

```

# Version presented to Marco before now

```
xeno> benchmarks
Running 3 benchmarks...
Benchmark xeno-memory-bench: RUNNING...

Case                          Allocated  GCs
4kb_hexml_dom                     3,808    0
4kb_xeno_sax                      6,328    0
4kb_xeno_dom                     21,512    0
4kb_xeno_dom-with-recovery       27,784    0
31kb_hexml_dom                   30,296    0
31kb_xeno_sax                     1,984    0
31kb_xeno_dom                    36,536    0
31kb_xeno_dom-with-recovery      16,360    0
211kb_hexml_dom                 211,184    0
211kb_xeno_sax                  353,080    0
211kb_xeno_dom                1,380,264    0
211kb_xeno_dom-with-recovery  1,999,552    0
Benchmark xeno-memory-bench: FINISH
Benchmark xeno-speed-bench: RUNNING...
benchmarking 4KB/hexml-dom
time                 6.016 μs   (5.992 μs .. 6.036 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 6.005 μs   (5.992 μs .. 6.021 μs)
std dev              48.46 ns   (40.73 ns .. 58.46 ns)

benchmarking 4KB/xeno-sax
time                 4.474 μs   (4.462 μs .. 4.487 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 4.471 μs   (4.457 μs .. 4.482 μs)
std dev              41.91 ns   (35.63 ns .. 50.00 ns)

benchmarking 4KB/xeno-sax-z
time                 3.057 μs   (3.049 μs .. 3.065 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 3.064 μs   (3.056 μs .. 3.075 μs)
std dev              30.85 ns   (25.02 ns .. 40.99 ns)

benchmarking 4KB/xeno-sax-ex
time                 6.427 μs   (6.419 μs .. 6.436 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 6.447 μs   (6.436 μs .. 6.461 μs)
std dev              43.53 ns   (32.05 ns .. 63.21 ns)

benchmarking 4KB/xeno-sax-ex-z
time                 5.485 μs   (5.472 μs .. 5.499 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 5.488 μs   (5.476 μs .. 5.504 μs)
std dev              45.20 ns   (34.57 ns .. 58.22 ns)

benchmarking 4KB/xeno-dom
time                 7.970 μs   (7.957 μs .. 7.986 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 7.993 μs   (7.977 μs .. 8.015 μs)
std dev              64.47 ns   (51.57 ns .. 79.70 ns)

benchmarking 4KB/xeno-dom-with-recovery
time                 9.755 μs   (9.731 μs .. 9.786 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 9.754 μs   (9.737 μs .. 9.775 μs)
std dev              66.24 ns   (48.87 ns .. 79.45 ns)

benchmarking 4KB/hexpat-sax
time                 42.05 μs   (41.84 μs .. 42.27 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 41.86 μs   (41.78 μs .. 42.00 μs)
std dev              364.0 ns   (283.2 ns .. 493.1 ns)

benchmarking 4KB/hexpat-dom
time                 109.3 μs   (108.8 μs .. 109.6 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 109.3 μs   (109.0 μs .. 109.6 μs)
std dev              938.7 ns   (825.6 ns .. 1.098 μs)

benchmarking 4KB/xml-dom
time                 831.0 μs   (829.7 μs .. 832.6 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 831.1 μs   (829.8 μs .. 833.1 μs)
std dev              5.493 μs   (4.243 μs .. 7.023 μs)

benchmarking 31KB/hexml-dom
time                 5.408 μs   (5.393 μs .. 5.424 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 5.406 μs   (5.397 μs .. 5.420 μs)
std dev              40.41 ns   (31.77 ns .. 52.67 ns)

benchmarking 31KB/xeno-sax
time                 1.976 μs   (1.974 μs .. 1.979 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.974 μs   (1.972 μs .. 1.977 μs)
std dev              8.007 ns   (6.435 ns .. 10.11 ns)

benchmarking 31KB/xeno-sax-z
time                 1.334 μs   (1.330 μs .. 1.339 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.334 μs   (1.332 μs .. 1.337 μs)
std dev              9.452 ns   (7.838 ns .. 12.57 ns)

benchmarking 31KB/xeno-sax-ex
time                 2.961 μs   (2.948 μs .. 2.974 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 2.971 μs   (2.956 μs .. 2.997 μs)
std dev              64.30 ns   (40.57 ns .. 105.2 ns)
variance introduced by outliers: 24% (moderately inflated)

benchmarking 31KB/xeno-sax-ex-z
time                 2.606 μs   (2.599 μs .. 2.615 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 2.612 μs   (2.607 μs .. 2.619 μs)
std dev              20.04 ns   (17.47 ns .. 23.26 ns)

benchmarking 31KB/xeno-dom
time                 3.679 μs   (3.664 μs .. 3.692 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 3.675 μs   (3.669 μs .. 3.683 μs)
std dev              22.95 ns   (19.22 ns .. 27.85 ns)

benchmarking 31KB/xeno-dom-with-recovery
time                 4.347 μs   (4.339 μs .. 4.354 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 4.354 μs   (4.345 μs .. 4.366 μs)
std dev              34.20 ns   (26.18 ns .. 47.66 ns)

benchmarking 31KB/hexpat-sax
time                 86.55 μs   (86.34 μs .. 86.80 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 86.91 μs   (86.67 μs .. 87.26 μs)
std dev              958.0 ns   (689.4 ns .. 1.463 μs)

benchmarking 31KB/hexpat-dom
time                 153.9 μs   (153.6 μs .. 154.4 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 153.9 μs   (153.6 μs .. 154.3 μs)
std dev              1.170 μs   (855.3 ns .. 1.498 μs)

benchmarking 31KB/xml-dom
time                 5.269 ms   (5.257 ms .. 5.283 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 5.263 ms   (5.254 ms .. 5.276 ms)
std dev              33.99 μs   (26.74 μs .. 46.48 μs)

benchmarking 211KB/hexml-dom
time                 183.3 μs   (182.9 μs .. 183.7 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 183.1 μs   (182.9 μs .. 183.6 μs)
std dev              1.151 μs   (895.3 ns .. 1.493 μs)

benchmarking 211KB/xeno-sax
time                 219.0 μs   (218.5 μs .. 219.6 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 219.0 μs   (218.6 μs .. 219.4 μs)
std dev              1.363 μs   (1.015 μs .. 1.840 μs)

benchmarking 211KB/xeno-sax-z
time                 151.9 μs   (151.7 μs .. 152.3 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 151.9 μs   (151.7 μs .. 152.2 μs)
std dev              940.4 ns   (729.6 ns .. 1.221 μs)

benchmarking 211KB/xeno-sax-ex
time                 316.4 μs   (315.8 μs .. 317.2 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 316.9 μs   (316.4 μs .. 317.7 μs)
std dev              2.178 μs   (1.721 μs .. 2.732 μs)

benchmarking 211KB/xeno-sax-ex-z
time                 267.3 μs   (266.6 μs .. 268.1 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 267.3 μs   (266.8 μs .. 268.0 μs)
std dev              1.956 μs   (1.527 μs .. 2.597 μs)

benchmarking 211KB/xeno-dom
time                 413.4 μs   (412.2 μs .. 414.9 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 411.7 μs   (410.4 μs .. 412.9 μs)
std dev              4.153 μs   (3.577 μs .. 5.410 μs)

benchmarking 211KB/xeno-dom-with-recovery
time                 478.4 μs   (477.5 μs .. 479.5 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 481.5 μs   (480.3 μs .. 482.8 μs)
std dev              4.104 μs   (3.368 μs .. 4.865 μs)

benchmarking 211KB/hexpat-sax
time                 4.477 ms   (4.450 ms .. 4.507 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 4.447 ms   (4.425 ms .. 4.471 ms)
std dev              68.33 μs   (57.03 μs .. 85.34 μs)

benchmarking 211KB/hexpat-dom
time                 9.838 ms   (9.778 ms .. 9.912 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 9.785 ms   (9.748 ms .. 9.835 ms)
std dev              116.0 μs   (93.06 μs .. 169.3 μs)

benchmarking 211KB/xml-dom
time                 48.58 ms   (47.50 ms .. 49.55 ms)
                     0.999 R²   (0.997 R² .. 1.000 R²)
mean                 49.48 ms   (48.86 ms .. 50.27 ms)
std dev              1.353 ms   (929.9 μs .. 1.852 ms)

Benchmark xeno-speed-bench: FINISH
Benchmark xeno-speed-big-files-bench: RUNNING...
xeno-speed-big-files-bench: data/ex/enwiki-20190901-pages-articles14.xml-p7697599p7744799.bz2: openBinaryFile: does not exist (No such file or directory)
Benchmark xeno-speed-big-files-bench: ERROR

--  While building package xeno-0.3.5.2 using:
      /home/m/.stack/setup-exe-cache/x86_64-linux-tinfo6/Cabal-simple_mPHDZzAJ_2.2.0.1_ghc-8.4.4 --builddir=.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.2.0.1 bench xeno-memory-bench xeno-speed-bench xeno-speed-big-files-bench
    Process exited with code: ExitFailure 1
```